### PR TITLE
docs: point to published SDLC and unify vulnerability reporting

### DIFF
--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -57,3 +57,8 @@ external database dependency. This means the app resets its state on each
 restart, which is fine for the exercise.
 
 <!-- Deliver the complete working project ready for GitHub publish. -->
+
+## SDLC
+
+These requirements are delivered under the family-wide Presidio SDLC:
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ python report.py --compare vulnerable fixed
 ## License
 
 MIT
+
+---
+
+## SDLC
+
+This repository is developed under the Presidio hardened-family SDLC:
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,18 @@
 
 ## Reporting a Vulnerability
 
-Do not open a public GitHub issue for security vulnerabilities.
+Please report security vulnerabilities by opening a private GitHub Security Advisory
+(via the "Security" tab → "Report a vulnerability") rather than a public issue.
 
-Email **security@presidio-group.eu** with description, reproduction steps, and impact.
-Acknowledgement within 48 hours; resolution within 7 days.
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You will receive an acknowledgement within 5 business days. We aim to release a patch
+within 30 days of a confirmed vulnerability.
 
 ## Important Notice
 
@@ -29,3 +37,9 @@ use. It must never be deployed to a network-accessible server.
 | **Argon2id** | Password hashing in fixed app |
 | **Parameterized SQL** | All queries use `?` placeholders in fixed app |
 | **Security logging** | Structured events for scan and exploit operations |
+
+## Software Development Lifecycle
+
+This repository is developed under the Presidio hardened-family SDLC. The public report
+— scope, standards mapping, threat-model gates, and supply-chain controls — is at
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.


### PR DESCRIPTION
## Summary

- Normalize the SECURITY.md Reporting section to the GitHub Security Advisories-only pattern used across the family.
- Add pointers to the published family SDLC in README.md, SECURITY.md, and PRESIDIO-REQ.md.
- SDLC: https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md

## Test plan

- [x] Diff scoped to docs files; no source or workflow changes
- [x] Links render on GitHub