### PR TITLE
Bump github/codeql-action/* from 4.36.2 to 4.37.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 updates:
+  # Only the repository root is scanned. `vulnerable_app/requirements.txt` pins
+  # outdated dependencies on purpose (see README.md) — do NOT add it here, or
+  # Dependabot will silently dismantle the lab exercise.
   - package-ecosystem: pip
     directory: "/"
     schedule:
@@ -16,6 +19,13 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # A single grouped PR per week. Multi-action releases (e.g. the three
+    # github/codeql-action/* sub-actions pinned in codeql.yml) otherwise arrive
+    # as separate PRs that all edit the same lines and mutually conflict.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - dependencies
       - ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
           queries: security-and-quality
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:python"


### PR DESCRIPTION
Supersedes Dependabot PRs #39, #40 and #41, which each bumped one of the
three github/codeql-action sub-actions pinned in codeql.yml. All three
target the same commit, so they were applied together to avoid three
mutually-conflicting single-line PRs on the same file.

Pin verified against upstream: cdf488f is the peeled commit of tag
v4.37.9, and the previous pin 8aad20d is the peeled commit of v4.36.2.
Version comments made exact (# v4 -> # v4.37.9) so pin drift is visible
in review.

Also group github-actions version updates into one weekly PR, and
document that vulnerable_app/ is deliberately excluded from Dependabot
scanning — its outdated pins are the lab exercise.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LNoSvC6CL75kkmoYtBXiqx